### PR TITLE
Do not abuse PathBuf::push("") for appending directory separator

### DIFF
--- a/src/windows/normalize.rs
+++ b/src/windows/normalize.rs
@@ -143,11 +143,11 @@ fn get_prefix(base: &BasePath) -> PrefixComponent<'_> {
 }
 
 fn push_separator(base: &mut BasePathBuf) {
-    base.replace_with(|mut base| {
-        // Add a separator if necessary.
-        base.push("");
-        base
-    });
+    // Add a separator if necessary.
+    let s = base.0.to_string_lossy();
+    if !s.ends_with('\\') && !s.ends_with(':') {
+        base.0.push(OsString::from(r"\"));
+    }
 }
 
 pub(super) fn push(base: &mut BasePathBuf, initial_path: &Path) {


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/89270 rust's pathbuf
push() normalizes the path if it is a verbatim path, so that the result
is still a valid verbatim path. This involves parsing reconstructing the
path.

Appending a path separator using push("") will no longer work, and if
it did, it would be very inefficient.

https://github.com/rust-lang/rust/issues/89658

Signed-off-by: Sean Young <sean@mess.org>