### PR TITLE
Switch from winapi to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ print_bytes = { version = "0.7", optional = true }
 serde = { version = "1.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["fileapi"] }
+windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 bincode = "1.3"
@@ -34,4 +34,4 @@ tempfile = "3.2"
 libc = "0.2"
 
 [features]
-localization = ["winapi/shellapi"]
+localization = ["windows-sys/Win32_UI_Shell", "windows-sys/Win32_UI_WindowsAndMessaging"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,12 @@ print_bytes = { version = "0.7", optional = true }
 serde = { version = "1.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.42", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.42", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 bincode = "1.3"
 tempfile = "3.2"
+windows-sys = { version = "0.42", features = ["Win32_Foundation"] }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 libc = "0.2"

--- a/src/windows/localize.rs
+++ b/src/windows/localize.rs
@@ -5,9 +5,7 @@ use std::os::windows::ffi::OsStrExt;
 use std::os::windows::ffi::OsStringExt;
 use std::path::Path;
 
-use winapi::shared::minwindef::UINT;
-use winapi::um::shellapi::SHGetFileInfoW;
-use winapi::um::shellapi::SHGFI_DISPLAYNAME;
+use windows_sys::Win32::UI::Shell::{SHGetFileInfoW, SHGFI_DISPLAYNAME};
 
 pub(super) fn name(path: &Path) -> Option<OsString> {
     let mut path: Vec<_> = path.as_os_str().encode_wide().collect();
@@ -22,7 +20,7 @@ pub(super) fn name(path: &Path) -> Option<OsString> {
             path.as_ptr(),
             0,
             path_info.as_mut_ptr(),
-            mem::size_of_val(&path_info) as UINT,
+            mem::size_of_val(&path_info) as _,
             SHGFI_DISPLAYNAME,
         )
     };

--- a/src/windows/localize.rs
+++ b/src/windows/localize.rs
@@ -5,7 +5,8 @@ use std::os::windows::ffi::OsStrExt;
 use std::os::windows::ffi::OsStringExt;
 use std::path::Path;
 
-use windows_sys::Win32::UI::Shell::{SHGetFileInfoW, SHGFI_DISPLAYNAME};
+use windows_sys::Win32::UI::Shell::SHGetFileInfoW;
+use windows_sys::Win32::UI::Shell::SHGFI_DISPLAYNAME;
 
 pub(super) fn name(path: &Path) -> Option<OsString> {
     let mut path: Vec<_> = path.as_os_str().encode_wide().collect();

--- a/src/windows/normalize.rs
+++ b/src/windows/normalize.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::ffi::OsString;
 use std::io;
-use std::mem;
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::ffi::OsStringExt;
 use std::path::Component;
@@ -11,17 +10,10 @@ use std::path::Prefix;
 use std::path::PrefixComponent;
 use std::ptr;
 
-use winapi::shared::minwindef::DWORD;
-use winapi::um::fileapi::GetFullPathNameW;
+use windows_sys::Win32::Storage::FileSystem::GetFullPathNameW;
 
 use super::BasePath;
 use super::BasePathBuf;
-
-macro_rules! static_assert {
-    ( $condition:expr ) => {
-        const _: () = assert!($condition, "static assertion failed");
-    };
-}
 
 const SEPARATOR: u16 = b'\\' as _;
 
@@ -103,9 +95,6 @@ pub(super) fn normalize_virtually(
         if capacity == 0 {
             break Err(io::Error::last_os_error());
         }
-
-        // This assertion should never fail.
-        static_assert!(mem::size_of::<DWORD>() <= mem::size_of::<usize>());
 
         let length = capacity as usize;
         if let Some(mut additional_capacity) =

--- a/src/windows/normalize.rs
+++ b/src/windows/normalize.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::ffi::OsString;
 use std::io;
+use std::mem;
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::ffi::OsStringExt;
 use std::path::Component;
@@ -14,6 +15,12 @@ use windows_sys::Win32::Storage::FileSystem::GetFullPathNameW;
 
 use super::BasePath;
 use super::BasePathBuf;
+
+macro_rules! static_assert {
+    ( $condition:expr ) => {
+        const _: () = assert!($condition, "static assertion failed");
+    };
+}
 
 const SEPARATOR: u16 = b'\\' as _;
 
@@ -95,6 +102,10 @@ pub(super) fn normalize_virtually(
         if capacity == 0 {
             break Err(io::Error::last_os_error());
         }
+
+        let _: u32 = capacity;
+        // This assertion should never fail.
+        static_assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
 
         let length = capacity as usize;
         if let Some(mut additional_capacity) =

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ mod common;
 
 #[cfg(windows)]
 #[rustfmt::skip]
-use winapi::shared::winerror::ERROR_INVALID_NAME;
+use windows_sys::Win32::Foundation::ERROR_INVALID_NAME;
 #[cfg(not(windows))]
 use libc::ENOENT as ERROR_INVALID_NAME;
 


### PR DESCRIPTION
The Rust ecosystem is migrating from winapi to windows-sys, for example https://github.com/tokio-rs/tokio/pull/5204